### PR TITLE
タスクの更新

### DIFF
--- a/frontend/src/components/molecules/taskForm/index.tsx
+++ b/frontend/src/components/molecules/taskForm/index.tsx
@@ -31,7 +31,6 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
     control,
     handleSubmit,
     // reset, 新規作成の時にフォームをクリアしたい
-    formState: { errors },
   } = useForm<taskFormValues>({
     resolver: yupResolver(taskSchema),
     mode: "onChange",
@@ -47,7 +46,7 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
         <Controller
           name="title"
           control={control}
-          render={({ field }) => (
+          render={({ field, fieldState: { error } }) => (
             <TextField
               {...field}
               id="title"
@@ -56,15 +55,15 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
               size="small"
               sx={{ width: "40%" }}
               required
-              error={"title" in errors}
-              helperText={errors.title?.message}
+              error={!!error}
+              helperText={error?.message}
             />
           )}
         />
         <Controller
           name="description"
           control={control}
-          render={({ field }) => (
+          render={({ field, fieldState: { error } }) => (
             <TextField
               {...field}
               id="description"
@@ -73,8 +72,8 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
               size="small"
               sx={{ width: "60%" }}
               required
-              error={"description" in errors}
-              helperText={errors.description?.message}
+              error={!!error}
+              helperText={error?.message}
             />
           )}
         />

--- a/frontend/src/components/molecules/taskForm/index.tsx
+++ b/frontend/src/components/molecules/taskForm/index.tsx
@@ -1,0 +1,90 @@
+import { yupResolver } from "@hookform/resolvers/yup";
+import { Button, Container, Stack, TextField } from "@mui/material";
+import { Controller, SubmitHandler, useForm } from "react-hook-form";
+import * as yup from "yup";
+
+export interface taskFormValues {
+  title: string;
+  description: string;
+}
+
+interface TaskFormProps {
+  onSubmit: SubmitHandler<taskFormValues>;
+}
+
+const TaskForm: React.VFC<TaskFormProps> = (props) => {
+  const taskSchema = yup.object({
+    title: yup
+      .string()
+      .max(20, "20文字以内にしてください")
+      .required("入力必須です"),
+    description: yup
+      .string()
+      .max(20, "20文字以内にしてください")
+      .required("入力必須です"),
+  });
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<taskFormValues>({
+    resolver: yupResolver(taskSchema),
+    mode: "onChange",
+    defaultValues: {
+      title: "",
+      description: "",
+    },
+  });
+
+  return (
+    <Container maxWidth="sm">
+      <Stack direction="row" spacing={1}>
+        <Controller
+          name="title"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              id="title"
+              label="タイトル"
+              variant="outlined"
+              size="small"
+              sx={{ width: "40%" }}
+              required
+              error={"title" in errors}
+              helperText={errors.title?.message}
+            />
+          )}
+        />
+        <Controller
+          name="description"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              {...field}
+              id="description"
+              label="内容"
+              variant="outlined"
+              size="small"
+              sx={{ width: "60%" }}
+              required
+              error={"description" in errors}
+              helperText={errors.description?.message}
+            />
+          )}
+        />
+        <Button
+          variant="contained"
+          sx={{ height: "40px" }}
+          onClick={handleSubmit(props.onSubmit)}
+        >
+          作成
+        </Button>
+      </Stack>
+    </Container>
+  );
+};
+
+export default TaskForm;

--- a/frontend/src/components/molecules/taskForm/index.tsx
+++ b/frontend/src/components/molecules/taskForm/index.tsx
@@ -30,7 +30,7 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
   const {
     control,
     handleSubmit,
-    reset,
+    // reset, 新規作成の時にフォームをクリアしたい
     formState: { errors },
   } = useForm<taskFormValues>({
     resolver: yupResolver(taskSchema),

--- a/frontend/src/components/molecules/taskForm/index.tsx
+++ b/frontend/src/components/molecules/taskForm/index.tsx
@@ -27,11 +27,7 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
       .required("入力必須です"),
   });
 
-  const {
-    control,
-    handleSubmit,
-    // reset, 新規作成の時にフォームをクリアしたい
-  } = useForm<taskFormValues>({
+  const { control, handleSubmit, reset } = useForm<taskFormValues>({
     resolver: yupResolver(taskSchema),
     mode: "onChange",
     defaultValues: {
@@ -80,7 +76,10 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
         <Button
           variant="contained"
           sx={{ height: "40px" }}
-          onClick={handleSubmit(props.onSubmit)}
+          onClick={handleSubmit((value) => {
+            props.onSubmit(value);
+            reset();
+          })}
         >
           {props.task ? "編集" : "作成"}
         </Button>

--- a/frontend/src/components/molecules/taskForm/index.tsx
+++ b/frontend/src/components/molecules/taskForm/index.tsx
@@ -3,12 +3,15 @@ import { Button, Container, Stack, TextField } from "@mui/material";
 import { Controller, SubmitHandler, useForm } from "react-hook-form";
 import * as yup from "yup";
 
+import { Task } from "../../../modules/apiClient/tasks/common";
+
 export interface taskFormValues {
   title: string;
   description: string;
 }
 
 interface TaskFormProps {
+  task?: Task;
   onSubmit: SubmitHandler<taskFormValues>;
 }
 
@@ -33,8 +36,8 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
     resolver: yupResolver(taskSchema),
     mode: "onChange",
     defaultValues: {
-      title: "",
-      description: "",
+      title: props.task ? props.task.name : "",
+      description: props.task ? props.task.description : "",
     },
   });
 
@@ -80,7 +83,7 @@ const TaskForm: React.VFC<TaskFormProps> = (props) => {
           sx={{ height: "40px" }}
           onClick={handleSubmit(props.onSubmit)}
         >
-          作成
+          {props.task ? "編集" : "作成"}
         </Button>
       </Stack>
     </Container>

--- a/frontend/src/components/organisms/editModal/index.tsx
+++ b/frontend/src/components/organisms/editModal/index.tsx
@@ -34,7 +34,6 @@ const EditModal: React.VFC<EditModalProps> = (props) => {
       };
       await updateTask(params);
       props.handleClose();
-      // reset();
     } catch (e) {
       console.log(e);
     }

--- a/frontend/src/components/organisms/editModal/index.tsx
+++ b/frontend/src/components/organisms/editModal/index.tsx
@@ -1,6 +1,9 @@
-import { Modal, Box, Typography } from "@mui/material";
+import { Modal, Box } from "@mui/material";
+import { SubmitHandler } from "react-hook-form";
 
 import { Task } from "../../../modules/apiClient/tasks/common";
+import { updateTask } from "../../../modules/apiClient/tasks/updateTask";
+import TaskForm, { taskFormValues } from "../../molecules/taskForm";
 
 interface EditModalProps {
   task: Task;
@@ -15,11 +18,26 @@ const EditModal: React.VFC<EditModalProps> = (props) => {
     top: "50%",
     left: "50%",
     transform: "translate(-50%, -50%)",
-    width: 400,
+    width: 600,
     bgcolor: "background.paper",
     border: "2px solid #000",
     boxShadow: 24,
     p: 4,
+  };
+
+  const onSubmit: SubmitHandler<taskFormValues> = async (formValues) => {
+    try {
+      const params = {
+        taskId: props.task.id,
+        name: formValues.title,
+        description: formValues.description,
+      };
+      await updateTask(params);
+      props.handleClose();
+      // reset();
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   return (
@@ -30,21 +48,7 @@ const EditModal: React.VFC<EditModalProps> = (props) => {
       aria-describedby="modal-description"
     >
       <Box sx={style}>
-        <Typography id="modal-title" variant="h6" component="h2">
-          Text in a modal
-        </Typography>
-        <Typography id="modal-description" sx={{ mt: 2 }}>
-          {props.task.description}
-          Lorem Ipsum is simply dummy text of the printing and typesetting
-          industry. Lorem Ipsum has been dummy text ever since the 1500s, when
-          an unknown printer took a galley of type and scrambled it to make a
-          type specimen book. It has survived not only five centuries, but also
-          the leap into electronic typesetting, remaining essentially unchanged.
-          It was popularised in the 1960s with the release of Letraset sheets
-          containing Lorem Ipsum passages, and more recently with desktop
-          publishing software like Aldus PageMaker including versions of Lorem
-          Ipsum.
-        </Typography>
+        <TaskForm onSubmit={onSubmit} />
       </Box>
     </Modal>
   );

--- a/frontend/src/components/organisms/editModal/index.tsx
+++ b/frontend/src/components/organisms/editModal/index.tsx
@@ -1,0 +1,53 @@
+import { Modal, Box, Typography } from "@mui/material";
+
+import { Task } from "../../../modules/apiClient/tasks/common";
+
+interface EditModalProps {
+  task: Task;
+  open: boolean;
+  handleOpen: () => void;
+  handleClose: () => void;
+}
+
+const EditModal: React.VFC<EditModalProps> = (props) => {
+  const style = {
+    position: "absolute" as const,
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+    width: 400,
+    bgcolor: "background.paper",
+    border: "2px solid #000",
+    boxShadow: 24,
+    p: 4,
+  };
+
+  return (
+    <Modal
+      open={props.open}
+      onClose={props.handleClose}
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+    >
+      <Box sx={style}>
+        <Typography id="modal-title" variant="h6" component="h2">
+          Text in a modal
+        </Typography>
+        <Typography id="modal-description" sx={{ mt: 2 }}>
+          {props.task.description}
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been dummy text ever since the 1500s, when
+          an unknown printer took a galley of type and scrambled it to make a
+          type specimen book. It has survived not only five centuries, but also
+          the leap into electronic typesetting, remaining essentially unchanged.
+          It was popularised in the 1960s with the release of Letraset sheets
+          containing Lorem Ipsum passages, and more recently with desktop
+          publishing software like Aldus PageMaker including versions of Lorem
+          Ipsum.
+        </Typography>
+      </Box>
+    </Modal>
+  );
+};
+
+export default EditModal;

--- a/frontend/src/components/organisms/editModal/index.tsx
+++ b/frontend/src/components/organisms/editModal/index.tsx
@@ -48,7 +48,7 @@ const EditModal: React.VFC<EditModalProps> = (props) => {
       aria-describedby="modal-description"
     >
       <Box sx={style}>
-        <TaskForm onSubmit={onSubmit} />
+        <TaskForm task={props.task} onSubmit={onSubmit} />
       </Box>
     </Modal>
   );

--- a/frontend/src/modules/apiClient/tasks/updateTask.ts
+++ b/frontend/src/modules/apiClient/tasks/updateTask.ts
@@ -1,0 +1,16 @@
+import { AxiosPromise } from "axios";
+
+import { axiosInstance } from "..";
+import { Task } from "./common";
+
+export interface UpdateTaskResponse {
+  updateTask: Task;
+}
+
+export const updateTask = (params: {
+  taskId: number;
+  name: string;
+  description: string;
+}): AxiosPromise<UpdateTaskResponse> => {
+  return axiosInstance.put(`/tasks/${params.taskId}`, params);
+};

--- a/frontend/src/modules/hooks/useFetchTasks.ts
+++ b/frontend/src/modules/hooks/useFetchTasks.ts
@@ -22,5 +22,6 @@ export const useFetchTasks = () => {
   return {
     tasks,
     setTasks,
+    fetchTasks,
   };
 };

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -66,7 +66,6 @@ const IndexPage = () => {
       };
       const { data } = await addTask(params);
       setTasks((prev) => [...prev, data.addTask]);
-      // reset(); 本当はここでフォームをクリアしたい
     } catch (e) {
       console.log(e);
     }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from "react";
+
 import { yupResolver } from "@hookform/resolvers/yup";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
@@ -18,20 +20,35 @@ import {
 import { Controller, useForm } from "react-hook-form";
 import * as yup from "yup";
 
+import EditModal from "../components/organisms/editModal";
 import { addTask } from "../modules/apiClient/tasks/addTask";
+import { Task } from "../modules/apiClient/tasks/common";
 import { deleteTask } from "../modules/apiClient/tasks/deleteTask";
 import { useFetchTasks } from "../modules/hooks/useFetchTasks";
 
 interface OperationButtonProps {
+  task: Task;
   onDelete: () => void;
 }
 
 const OperationButtons: React.VFC<OperationButtonProps> = (props) => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  console.log(open);
+
   return (
     <Stack direction="row">
-      <IconButton aria-label="edit">
+      <IconButton aria-label="edit" onClick={handleOpen}>
         <EditIcon />
       </IconButton>
+      <EditModal
+        task={props.task}
+        open={open}
+        handleOpen={handleOpen}
+        handleClose={handleClose}
+      />
       <IconButton edge="end" aria-label="delete" onClick={props.onDelete}>
         <DeleteIcon />
       </IconButton>
@@ -154,6 +171,7 @@ const IndexPage = () => {
                 key={task.id}
                 secondaryAction={
                   <OperationButtons
+                    task={task}
                     onDelete={() => {
                       handleDelete(task.id);
                     }}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -66,7 +66,7 @@ const IndexPage = () => {
       };
       const { data } = await addTask(params);
       setTasks((prev) => [...prev, data.addTask]);
-      // reset();
+      // reset(); 本当はここでフォームをクリアしたい
     } catch (e) {
       console.log(e);
     }

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";


### PR DESCRIPTION
# 目的
タスクを更新できるようにする。

# 修正内容
- 更新機能の作成
  - APIを叩いてタスクを更新するロジック
  - 更新後にタスク一覧を更新
- 新規作成フォームと更新フォームを共通化

# 特に共有すべきこと
特になし

# 特に見てもらいたい点
コメントした箇所

# 動作確認
https://user-images.githubusercontent.com/49134785/179207855-29f50165-3fb3-4cb8-9e41-8b12c572c6c1.mov

# 参考資料
- https://github.com/KazukiHayase/norticle-frontend