### PR TITLE
ログイン機能の導入

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,2 @@
+NEXT_PUBLIC_HOST=http://localhost:3333
 NEXT_PUBLIC_REST_HOST=http://localhost:8888/api/rest

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
+    "@auth0/auth0-react": "^1.10.2",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@hookform/resolvers": "^2.9.3",

--- a/frontend/src/components/organisms/header/index.tsx
+++ b/frontend/src/components/organisms/header/index.tsx
@@ -1,57 +1,39 @@
 import { useAuth0 } from "@auth0/auth0-react";
-import LogoutIcon from "@mui/icons-material/Logout";
-import {
-  Box,
-  AppBar,
-  Toolbar,
-  Typography,
-  Button,
-  IconButton,
-} from "@mui/material";
-
-const LoginButton = ({ onSignup, onLogin }) => {
-  return (
-    <>
-      <Button color="inherit" onClick={onSignup}>
-        SIGN UP
-      </Button>
-      <Button variant="contained" sx={{ ml: 1 }} onClick={onLogin}>
-        SIGN IN
-      </Button>
-    </>
-  );
-};
-
-const LogoutButton = ({ onLogout }) => {
-  return (
-    <IconButton onClick={onLogout}>
-      <LogoutIcon />
-    </IconButton>
-  );
-};
+import { Box, AppBar, Toolbar, Typography, Button } from "@mui/material";
 
 const Header = () => {
-  const { isLoading, isAuthenticated, loginWithRedirect, logout } = useAuth0();
+  const { isLoading, isAuthenticated, loginWithRedirect } = useAuth0();
 
   return (
-    <Box sx={{ mb: 3 }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-            TODO LIST
-          </Typography>
-          {!isLoading &&
-            (isAuthenticated ? (
-              <LogoutButton onLogout={() => logout()} />
-            ) : (
-              <LoginButton
-                onSignup={() => loginWithRedirect({ screen_hint: "signup" })}
-                onLogin={() => loginWithRedirect({ screen_hint: "login" })}
-              />
-            ))}
-        </Toolbar>
-      </AppBar>
-    </Box>
+    !isLoading &&
+    !isAuthenticated && (
+      <Box sx={{ mb: 3 }}>
+        <AppBar position="static">
+          <Toolbar>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+              TODO LIST
+            </Typography>
+            <Button
+              color="inherit"
+              onClick={() => {
+                loginWithRedirect({ screen_hint: "signup" });
+              }}
+            >
+              SIGN UP
+            </Button>
+            <Button
+              variant="contained"
+              sx={{ ml: 1 }}
+              onClick={() => {
+                loginWithRedirect({ screen_hint: "login" });
+              }}
+            >
+              SIGN IN
+            </Button>
+          </Toolbar>
+        </AppBar>
+      </Box>
+    )
   );
 };
 

--- a/frontend/src/components/organisms/header/index.tsx
+++ b/frontend/src/components/organisms/header/index.tsx
@@ -1,0 +1,58 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import LogoutIcon from "@mui/icons-material/Logout";
+import {
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  Button,
+  IconButton,
+} from "@mui/material";
+
+const LoginButton = ({ onSignup, onLogin }) => {
+  return (
+    <>
+      <Button color="inherit" onClick={onSignup}>
+        SIGN UP
+      </Button>
+      <Button variant="contained" sx={{ ml: 1 }} onClick={onLogin}>
+        SIGN IN
+      </Button>
+    </>
+  );
+};
+
+const LogoutButton = ({ onLogout }) => {
+  return (
+    <IconButton onClick={onLogout}>
+      <LogoutIcon />
+    </IconButton>
+  );
+};
+
+const Header = () => {
+  const { isLoading, isAuthenticated, loginWithRedirect, logout } = useAuth0();
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            TODO LIST
+          </Typography>
+          {!isLoading &&
+            (isAuthenticated ? (
+              <LogoutButton onLogout={() => logout()} />
+            ) : (
+              <LoginButton
+                onSignup={() => loginWithRedirect({ screen_hint: "signup" })}
+                onLogin={() => loginWithRedirect({ screen_hint: "login" })}
+              />
+            ))}
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/organisms/loggedInHeader/index.tsx
+++ b/frontend/src/components/organisms/loggedInHeader/index.tsx
@@ -1,0 +1,24 @@
+import { useAuth0 } from "@auth0/auth0-react";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { Box, AppBar, Toolbar, Typography, IconButton } from "@mui/material";
+
+const LoggedInHeader = () => {
+  const { logout } = useAuth0();
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            TODO LIST
+          </Typography>
+          <IconButton onClick={() => logout()}>
+            <LogoutIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};
+
+export default LoggedInHeader;

--- a/frontend/src/components/organisms/loggedInHeader/index.tsx
+++ b/frontend/src/components/organisms/loggedInHeader/index.tsx
@@ -1,8 +1,8 @@
-import { useAuth0 } from "@auth0/auth0-react";
+import { useAuth0, withAuthenticationRequired } from "@auth0/auth0-react";
 import LogoutIcon from "@mui/icons-material/Logout";
 import { Box, AppBar, Toolbar, Typography, IconButton } from "@mui/material";
 
-const LoggedInHeader = () => {
+const LoggedInHeader = withAuthenticationRequired(() => {
   const { logout } = useAuth0();
 
   return (
@@ -19,6 +19,6 @@ const LoggedInHeader = () => {
       </AppBar>
     </Box>
   );
-};
+});
 
 export default LoggedInHeader;

--- a/frontend/src/components/templates/layout/index.tsx
+++ b/frontend/src/components/templates/layout/index.tsx
@@ -1,0 +1,18 @@
+import { ReactElement } from "react";
+
+import LoggedInHeader from "../../organisms/loggedInHeader";
+
+type LayoutProps = Required<{
+  readonly children: ReactElement;
+}>;
+
+const Layout = ({ children }: LayoutProps) => {
+  return (
+    <>
+      <LoggedInHeader />
+      {children}
+    </>
+  );
+};
+
+export default Layout;

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { Auth0Provider } from "@auth0/auth0-react";
 import { ThemeProvider, CssBaseline } from "@mui/material";
 
 import { theme } from "../theme";
@@ -6,10 +7,16 @@ import type { AppProps } from "next/app";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Component {...pageProps} />
-    </ThemeProvider>
+    <Auth0Provider
+      domain={process.env.NEXT_PUBLIC_AUTH0_DOMAIN}
+      clientId={process.env.NEXT_PUBLIC_AUTH0_CLIENT_ID}
+      redirectUri={process.env.NEXT_PUBLIC_HOST}
+    >
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </Auth0Provider>
   );
 };
 

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,11 +1,24 @@
+import { ReactElement, ReactNode } from "react";
+
 import { Auth0Provider } from "@auth0/auth0-react";
 import { ThemeProvider, CssBaseline } from "@mui/material";
+import { NextPage } from "next";
 
 import { theme } from "../theme";
 
 import type { AppProps } from "next/app";
 
-const MyApp = ({ Component, pageProps }: AppProps) => {
+export type NextPageWithLayout = NextPage & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
+  const getLayout = Component.getLayout ?? ((page) => page);
+
   return (
     <Auth0Provider
       domain={process.env.NEXT_PUBLIC_AUTH0_DOMAIN}
@@ -14,7 +27,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
     >
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Component {...pageProps} />
+        {getLayout(<Component {...pageProps} />)}
       </ThemeProvider>
     </Auth0Provider>
   );

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,7 +1,6 @@
 import { Auth0Provider } from "@auth0/auth0-react";
 import { ThemeProvider, CssBaseline } from "@mui/material";
 
-import Header from "../components/organisms/header";
 import { theme } from "../theme";
 
 import type { AppProps } from "next/app";
@@ -15,7 +14,6 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
     >
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <Header />
         <Component {...pageProps} />
       </ThemeProvider>
     </Auth0Provider>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { Auth0Provider } from "@auth0/auth0-react";
 import { ThemeProvider, CssBaseline } from "@mui/material";
 
+import Header from "../components/organisms/header";
 import { theme } from "../theme";
 
 import type { AppProps } from "next/app";
@@ -14,6 +15,7 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
     >
       <ThemeProvider theme={theme}>
         <CssBaseline />
+        <Header />
         <Component {...pageProps} />
       </ThemeProvider>
     </Auth0Provider>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ReactElement, useState } from "react";
 
 import { withAuthenticationRequired } from "@auth0/auth0-react";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -18,11 +18,12 @@ import { SubmitHandler } from "react-hook-form";
 
 import TaskForm, { taskFormValues } from "../components/molecules/taskForm";
 import EditModal from "../components/organisms/editModal";
-import Header from "../components/organisms/header";
+import Layout from "../components/templates/layout";
 import { addTask } from "../modules/apiClient/tasks/addTask";
 import { Task } from "../modules/apiClient/tasks/common";
 import { deleteTask } from "../modules/apiClient/tasks/deleteTask";
 import { useFetchTasks } from "../modules/hooks/useFetchTasks";
+import { NextPageWithLayout } from "./_app";
 
 interface OperationButtonProps {
   task: Task;
@@ -55,7 +56,7 @@ const OperationButtons: React.VFC<OperationButtonProps> = ({
   );
 };
 
-const IndexPage = () => {
+const IndexPage: NextPageWithLayout = () => {
   const { tasks, setTasks, fetchTasks } = useFetchTasks();
 
   const onSubmit: SubmitHandler<taskFormValues> = async ({
@@ -86,7 +87,6 @@ const IndexPage = () => {
 
   return (
     <>
-      <Header />
       <TaskForm onSubmit={onSubmit} />
       {tasks && (
         <Container maxWidth="sm">
@@ -124,6 +124,10 @@ const IndexPage = () => {
       )}
     </>
   );
+};
+
+IndexPage.getLayout = (page: ReactElement) => {
+  return <Layout>{page}</Layout>;
 };
 
 export default withAuthenticationRequired(IndexPage);

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -17,7 +17,6 @@ import { SubmitHandler } from "react-hook-form";
 
 import TaskForm, { taskFormValues } from "../components/molecules/taskForm";
 import EditModal from "../components/organisms/editModal";
-import Header from "../components/organisms/header";
 import { addTask } from "../modules/apiClient/tasks/addTask";
 import { Task } from "../modules/apiClient/tasks/common";
 import { deleteTask } from "../modules/apiClient/tasks/deleteTask";
@@ -85,7 +84,6 @@ const IndexPage = () => {
 
   return (
     <>
-      <Header />
       <TaskForm onSubmit={onSubmit} />
       {tasks && (
         <Container maxWidth="sm">

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -12,12 +12,12 @@ import {
   ListItemAvatar,
   ListItemText,
   Stack,
-  Typography,
 } from "@mui/material";
 import { SubmitHandler } from "react-hook-form";
 
 import TaskForm, { taskFormValues } from "../components/molecules/taskForm";
 import EditModal from "../components/organisms/editModal";
+import Header from "../components/organisms/header";
 import { addTask } from "../modules/apiClient/tasks/addTask";
 import { Task } from "../modules/apiClient/tasks/common";
 import { deleteTask } from "../modules/apiClient/tasks/deleteTask";
@@ -85,9 +85,7 @@ const IndexPage = () => {
 
   return (
     <>
-      <Typography variant="h3" align="center" marginTop={3} gutterBottom>
-        TODO LIST
-      </Typography>
+      <Header />
       <TaskForm onSubmit={onSubmit} />
       {tasks && (
         <Container maxWidth="sm">

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -18,6 +18,7 @@ import { SubmitHandler } from "react-hook-form";
 
 import TaskForm, { taskFormValues } from "../components/molecules/taskForm";
 import EditModal from "../components/organisms/editModal";
+import Header from "../components/organisms/header";
 import { addTask } from "../modules/apiClient/tasks/addTask";
 import { Task } from "../modules/apiClient/tasks/common";
 import { deleteTask } from "../modules/apiClient/tasks/deleteTask";
@@ -85,6 +86,7 @@ const IndexPage = () => {
 
   return (
     <>
+      <Header />
       <TaskForm onSubmit={onSubmit} />
       {tasks && (
         <Container maxWidth="sm">

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -56,7 +56,7 @@ const OperationButtons: React.VFC<OperationButtonProps> = ({
   );
 };
 
-const IndexPage: NextPageWithLayout = () => {
+const IndexPage: NextPageWithLayout = withAuthenticationRequired(() => {
   const { tasks, setTasks, fetchTasks } = useFetchTasks();
 
   const onSubmit: SubmitHandler<taskFormValues> = async ({
@@ -124,10 +124,10 @@ const IndexPage: NextPageWithLayout = () => {
       )}
     </>
   );
-};
+});
 
 IndexPage.getLayout = (page: ReactElement) => {
   return <Layout>{page}</Layout>;
 };
 
-export default withAuthenticationRequired(IndexPage);
+export default IndexPage;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { withAuthenticationRequired } from "@auth0/auth0-react";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
@@ -123,4 +124,4 @@ const IndexPage = () => {
   );
 };
 
-export default IndexPage;
+export default withAuthenticationRequired(IndexPage);

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -1,12 +1,13 @@
-import { useEffect } from "react";
+import { ReactElement, useEffect } from "react";
 
 import { useAuth0 } from "@auth0/auth0-react";
 import { Container } from "@mui/material";
 import router from "next/router";
 
 import Header from "../../components/organisms/header";
+import { NextPageWithLayout } from "../_app";
 
-const Login = () => {
+const Login: NextPageWithLayout = () => {
   const { isLoading, isAuthenticated } = useAuth0();
 
   useEffect(() => {
@@ -18,11 +19,17 @@ const Login = () => {
   return (
     !isLoading &&
     !isAuthenticated && (
-      <>
-        <Header />
-        <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
-      </>
+      <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
     )
+  );
+};
+
+Login.getLayout = (page: ReactElement) => {
+  return (
+    <>
+      <Header />
+      {page}
+    </>
   );
 };
 

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -1,14 +1,7 @@
 import { Container } from "@mui/material";
 
-import Header from "../../components/organisms/header";
-
 const Login = () => {
-  return (
-    <>
-      <Header />
-      <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
-    </>
-  );
+  return <Container maxWidth="sm">やることをきれいに管理しよう！</Container>;
 };
 
 export default Login;

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -27,6 +27,7 @@ const Login: NextPageWithLayout = () => {
 Login.getLayout = (page: ReactElement) => {
   return (
     <>
+      {/* テスト */}
       <Header />
       {page}
     </>

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -1,0 +1,14 @@
+import { Container } from "@mui/material";
+
+import Header from "../../components/organisms/header";
+
+const Login = () => {
+  return (
+    <>
+      <Header />
+      <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
+    </>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -1,13 +1,28 @@
+import { useEffect } from "react";
+
+import { useAuth0 } from "@auth0/auth0-react";
 import { Container } from "@mui/material";
+import router from "next/router";
 
 import Header from "../../components/organisms/header";
 
 const Login = () => {
+  const { isLoading, isAuthenticated } = useAuth0();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.replace("/");
+    }
+  }, [isAuthenticated]);
+
   return (
-    <>
-      <Header />
-      <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
-    </>
+    !isLoading &&
+    !isAuthenticated && (
+      <>
+        <Header />
+        <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
+      </>
+    )
   );
 };
 

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -27,7 +27,6 @@ const Login: NextPageWithLayout = () => {
 Login.getLayout = (page: ReactElement) => {
   return (
     <>
-      {/* テスト */}
       <Header />
       {page}
     </>

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -1,7 +1,14 @@
 import { Container } from "@mui/material";
 
+import Header from "../../components/organisms/header";
+
 const Login = () => {
-  return <Container maxWidth="sm">やることをきれいに管理しよう！</Container>;
+  return (
+    <>
+      <Header />
+      <Container maxWidth="sm">やることをきれいに管理しよう！</Container>
+    </>
+  );
 };
 
 export default Login;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+"@auth0/auth0-react@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-react/-/auth0-react-1.10.2.tgz#036d2d73ea65a8f7096a30087b6bc44e34b66de3"
+  integrity sha512-s622ac/gLZ9pUX7d5dOhRggF4VI3MaLLCPVBFR5CKOGcPtPG80/4w2jMoBQtRRn6uKS6IVMWAUAFKWB7yATAoQ==
+  dependencies:
+    "@auth0/auth0-spa-js" "^1.22.0"
+
+"@auth0/auth0-spa-js@^1.22.0":
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-1.22.1.tgz#ae463b9820aa323525918e2f49cededb042f84e3"
+  integrity sha512-l0FCmiN3XubpgCtB3U0ds4h+5WQNTnIF4eLT/fudHEtcyrT65QF/03LybGVdLyuvqdIF/D6OQsfjwYw0Ms605Q==
+  dependencies:
+    abortcontroller-polyfill "^1.7.3"
+    browser-tabs-lock "^1.2.15"
+    core-js "^3.22.6"
+    es-cookie "^1.3.2"
+    fast-text-encoding "^1.0.3"
+    promise-polyfill "^8.2.3"
+    unfetch "^4.2.0"
+
 "@babel/code-frame@^7.0.0":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -514,6 +534,11 @@
     "@typescript-eslint/types" "5.28.0"
     eslint-visitor-keys "^3.3.0"
 
+abortcontroller-polyfill@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
+  integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -636,6 +661,13 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browser-tabs-lock@^1.2.15:
+  version "1.2.15"
+  resolved "https://registry.yarnpkg.com/browser-tabs-lock/-/browser-tabs-lock-1.2.15.tgz#d5012e652e2a0cb4eba471b0a2300c2fa5d92788"
+  integrity sha512-J8K9vdivK0Di+b8SBdE7EZxDr88TnATing7XoLw6+nFkXMQ6sVBh92K3NQvZlZU91AIkFRi0w3sztk5Z+vsswA==
+  dependencies:
+    lodash ">=4.17.21"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -718,6 +750,11 @@ convert-source-map@^1.5.0:
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
+
+core-js@^3.22.6:
+  version "3.23.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.23.4.tgz#92d640faa7f48b90bbd5da239986602cfc402aa6"
+  integrity sha512-vjsKqRc1RyAJC3Ye2kYqgfdThb3zYnx9CrqoCcjMOENMtQPC7ZViBvlDxwYU/2z2NI/IPuiXw5mT4hWhddqjzQ==
 
 cosmiconfig@^6.0.0:
   version "6.0.0"
@@ -852,6 +889,11 @@ es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
+
+es-cookie@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/es-cookie/-/es-cookie-1.3.2.tgz#80e831597f72a25721701bdcb21d990319acd831"
+  integrity sha512-UTlYYhXGLOy05P/vKVT2Ui7WtC7NiRzGtJyAKKn32g5Gvcjn7KAClLPWlipCtxIus934dFg9o9jXiBL0nP+t9Q==
 
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
@@ -1088,6 +1130,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-text-encoding@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz#bf1898ad800282a4e53c0ea9690704dd26e4298e"
+  integrity sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -1511,7 +1558,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.21:
+lodash@>=4.17.21, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -1788,6 +1835,11 @@ prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+promise-polyfill@^8.2.3:
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.3.tgz#2edc7e4b81aff781c88a0d577e5fe9da822107c6"
+  integrity sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg==
 
 prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
@@ -2134,6 +2186,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
# 目的
ログイン機能をつける。

# 修正内容
- auth0の導入
- ヘッダーの作成
  - ログイン前はサインアップボタン・サインインボタンを表示
  - ログイン後はログアウトボタンを表示
- `/login` ページの作成
- ログイン前にログイン必須ページ `/` にアクセスした場合はログイン画面にリダイレクトさせる
- ログイン後に `/login` にアクセスした場合はログイン後の初期ページ `/` にリダイレクトさせる

# 特に共有すべきこと
本来ログイン後はログインユーザーに紐づくタスクだけを表示したいが、このPRではスコープ外とします。

# 特に見てもらいたい点
- 全体的におかしいところがなさそうか
- もっとこうした方が良い、などあれば🙏
- コメントした箇所

# 動作確認
https://user-images.githubusercontent.com/49134785/179496509-c71e66e7-ed0c-47df-954b-2b9737e888af.mov

# 参考資料
- https://auth0.com/docs/quickstart/spa/react/01-login
- https://auth0.github.io/auth0-react/#protect-a-route
- https://nextjs.org/docs/basic-features/layouts#per-page-layouts
- https://zenn.dev/hisho/articles/fe9f4ec4a8e691